### PR TITLE
Fix base template script path and button ids

### DIFF
--- a/src/web/templates/base.html
+++ b/src/web/templates/base.html
@@ -20,6 +20,6 @@
         {% endblock %}
     </div>
 
-    <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+    <script src="{{ url_for('static', filename='scripts.js') }}"></script>
 </body>
 </html>

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -158,11 +158,11 @@
   </div>
 
   <div class="control-sections">
-    <div class="control-section Refreshdisplay">
+    <div class="control-section Refreshdisplay" id="refreshDisplay-button">
       <div>Refresh display</div>
     </div>
-    
-    <div class="control-section Cleardisplay">
+
+    <div class="control-section Cleardisplay" id="clearDisplay-button">
       <div>Clear display</div>
     </div>
     


### PR DESCRIPTION
## Summary
- include the correct scripts.js in base template
- attach IDs to the refresh and clear buttons so scripts work

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a222ee4008326b6c7b61077f92dfb