### PR TITLE
Fix variable typo

### DIFF
--- a/src/displayManager.py
+++ b/src/displayManager.py
@@ -94,8 +94,8 @@ class DisplayManager:
         image = Image.open(path)
         aspect_ratio = image.height / image.width
         adjusted_height = int(width * aspect_ratio)
-        resized_iamge = image.resize((width, adjusted_height))
-        self.image.paste(resized_iamge, (x, y))
+        resized_image = image.resize((width, adjusted_height))
+        self.image.paste(resized_image, (x, y))
 
     def clearScreen():
         try:


### PR DESCRIPTION
## Summary
- rename `resized_iamge` to `resized_image` in `displayManager`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684a220c5150832694561fd941975f0c