### PR TITLE
Fix refresh display callback in web server

### DIFF
--- a/web.py
+++ b/web.py
@@ -5,6 +5,6 @@ import main
 
 
 
-Server = Webserver(ScreenControls.clearScreen, main.main(debug=True))
+Server = Webserver(ScreenControls.clearScreen, lambda: main.main(debug=True))
 
 Server.start_server(80, 24, 80, 24)


### PR DESCRIPTION
## Summary
- ensure refresh endpoint calls `main.main` rather than executing it during initialization

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a200d33188326bdace51ac755917d