### PR TITLE
Add working control buttons

### DIFF
--- a/src/web.py
+++ b/src/web.py
@@ -41,13 +41,15 @@ class Webserver:
         def settings():
             return render_template('settings.html')
         
-        @self.app.route('/clear-display', methods=['POST'])
+        @self.app.route('/clear-display', methods=['GET', 'POST'])
         def clear_display_route():
             self.clear_display()
+            return "Display cleared"
 
-        @self.app.route('/refresh-display', methods=['POST'])
+        @self.app.route('/refresh-display', methods=['GET', 'POST'])
         def refresh_display_route():
             self.refresh_display()
+            return "Display refreshed"
             
 
         if self.should_run:

--- a/src/web/static/scripts.js
+++ b/src/web/static/scripts.js
@@ -1,19 +1,24 @@
 document.getElementById("clearDisplay-button").addEventListener("click", function() {
     fetch('/clear-display', {
-      method: 'POST',
+        method: 'POST',
     })
     .then(response => response.text())
     .then(data => {
-      console.log(data); // Log the response from the server
+        console.log(data);
     });
-  });
+});
 
 document.getElementById("refreshDisplay-button").addEventListener("click", function() {
-  fetch('/refresh-display', {
-    method: 'POST',
-  })
-  .then(response => response.text())
-  .then(data => {
-    console.log(data); // Log the response from the server
-  });
+    fetch('/refresh-display', {
+        method: 'POST',
+    })
+    .then(response => response.text())
+    .then(data => {
+        console.log(data);
+    });
 });
+
+document.getElementById("settings-button").addEventListener("click", function() {
+    window.location.href = '/settings';
+});
+

--- a/src/web/templates/home.html
+++ b/src/web/templates/home.html
@@ -74,6 +74,8 @@
     border-radius: 10px;
     padding: 10px;
     color: white;
+    border: none;
+    cursor: pointer;
   }
 
   img.Vistalogo {
@@ -158,18 +160,20 @@
   </div>
 
   <div class="control-sections">
-    <div class="control-section Refreshdisplay" id="refreshDisplay-button">
-      <div>Refresh display</div>
-    </div>
+    <button class="control-section Refreshdisplay" id="refreshDisplay-button">
+      Refresh display
+    </button>
 
-    <div class="control-section Cleardisplay" id="clearDisplay-button">
-      <div>Clear display</div>
-    </div>
-    
-    <div class="control-section Settings">
-      <div>Settings</div>
-    </div>
+    <button class="control-section Cleardisplay" id="clearDisplay-button">
+      Clear display
+    </button>
+
+    <button class="control-section Settings" id="settings-button">
+      Settings
+    </button>
   </div>
+
+  <script src="{{ url_for('static', filename='scripts.js') }}"></script>
   
   <img class="Thecabinlogo" src="{{ url_for('static', filename='assets/theCabin.png') }}" alt="The Cabin Logo">
 </div>


### PR DESCRIPTION
## Summary
- style control buttons as interactive elements
- load front-end scripts in the home template
- make the control sections actual `<button>` tags
- allow GET requests to the display action routes

## Testing
- `python -m py_compile src/web.py`


------
https://chatgpt.com/codex/tasks/task_e_684a294db8e48326b4d308b69be578d7